### PR TITLE
Specify Pushover library version in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "doctrine/orm": "^3.1",
         "gpslab/geoip2": "^2.1",
         "secit-pl/imap-bundle": "^3.1",
-        "serhiy/pushover": "*",
+        "serhiy/pushover": "^1.6",
         "symfony/apache-pack": "^1.0",
         "symfony/console": "7.1.*",
         "symfony/dotenv": "7.1.*",


### PR DESCRIPTION
Hello. This is a very simple pull request. I'm the author of the PHP Pushover library. I've noticed that you're requiring this library in your composer.json with a wildcard. I think it's better to require a specific version, because when the library is updated to version 2, there will be breaking changes and deprecated functionality in the library. And then, as soon as you update your dependencies, even though it is unlikely, you may still have issues sending Pushover notifications.