### PR TITLE
Use dynamic PHP-FPM process manager by default

### DIFF
--- a/dockerfiles/etc/php83/php-fpm.d/www.conf
+++ b/dockerfiles/etc/php83/php-fpm.d/www.conf
@@ -19,7 +19,7 @@ listen = /run/php-fpm.sock
 pm.status_path = /fpm-status
 
 ; Ondemand process manager
-pm = static
+pm = dynamic
 
 ; The number of child processes to be created when pm is set to 'static' and the
 ; maximum number of child processes when pm is set to 'dynamic' or 'ondemand'.
@@ -30,7 +30,12 @@ pm = static
 ; forget to tweak pm.* to fit your needs.
 ; Note: Used when pm is set to 'static', 'dynamic' or 'ondemand'
 ; Note: This value is mandatory.
-pm.max_children = 100
+pm.max_children = 10
+
+; Additional server process configuration
+pm.start_servers = 2
+pm.min_spare_servers = 2
+pm.max_spare_servers = 5
 
 ; The number of seconds after which an idle process will be killed.
 ; Note: Used only when pm is set to 'ondemand'


### PR DESCRIPTION
This PR changes the default PHP-FPM process manager from `static` to `dynamic` to reduce the idle memory footprint of the Docker container.

Changes:
- Change `pm` from `static` to `dynamic`
- Set `pm.max_children` to `10`
- Configure:
  - `pm.start_servers = 2`
  - `pm.min_spare_servers = 2`
  - `pm.max_spare_servers = 5`
- Update the outdated comment to match the new configuration

These defaults should be sufficient for the vast majority of self-hosted installations while significantly reducing idle memory usage.

Closes #221